### PR TITLE
fix(committee-config): correct broken handles and complete roster

### DIFF
--- a/data/committee-config.json
+++ b/data/committee-config.json
@@ -3,8 +3,9 @@
   "quorum_rule": "simple_majority",
   "members": [
     {"login": "michaeloboyle", "name": "Michael O'Boyle", "role": "chair"},
-    {"login": "ruebot", "name": "Nick Ruest", "role": "member"},
-    {"login": "mrjcleaver2", "name": "Martin Cleaver", "role": "member"},
-    {"login": "ransonrob", "name": "Robert Ranson", "role": "member"}
+    {"login": "nicholas-ruest", "name": "Nick Ruest", "role": "member"},
+    {"login": "mrjcleaver", "name": "Martin Cleaver", "role": "member"},
+    {"login": "shaal", "name": "Ofer Shaal", "role": "member"},
+    {"login": "inde5media", "name": "Mat Mathews", "role": "member"}
   ]
 }


### PR DESCRIPTION
See commit. Corrects ruebot->nicholas-ruest, mrjcleaver2->mrjcleaver, adds shaal+inde5media, drops dead ransonrob. All 5 logins verified resolving + collaborators with push/triage.