### PR TITLE
fix(committee-config): add Robert Ranson (rcraw) to roster

### DIFF
--- a/data/committee-config.json
+++ b/data/committee-config.json
@@ -6,6 +6,7 @@
     {"login": "nicholas-ruest", "name": "Nick Ruest", "role": "member"},
     {"login": "mrjcleaver", "name": "Martin Cleaver", "role": "member"},
     {"login": "shaal", "name": "Ofer Shaal", "role": "member"},
-    {"login": "inde5media", "name": "Mat Mathews", "role": "member"}
+    {"login": "inde5media", "name": "Mat Mathews", "role": "member"},
+    {"login": "rcraw", "name": "Robert Ranson", "role": "member"}
   ]
 }


### PR DESCRIPTION
Follow-up to #18, which corrected the broken handles but deferred Rob Ranson pending his confirmed handle.

Rob's handle is **rcraw** (confirmed by Michael; verified via API: resolves to a real account id 61807077, already a `community-projects` collaborator with **write** access, so he can score immediately).

Adds him as a 6th `member`. Roster is now complete: chair + 5 members, every login resolving with push/triage.