### PR TITLE
feat(dashboard): GitHub Pages committee + submissions dashboard

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,60 @@
+name: Dashboard (GitHub Pages)
+
+# Regenerates docs/data/dashboard.json (committee + submissions + approved registry)
+# and publishes docs/ to GitHub Pages.
+#
+# Activation: the first run auto-enables Pages (configure-pages enablement: true),
+# so merging this workflow to the default branch publishes the site. To stage the
+# code without publishing, hold the merge or set enablement: false below.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'   # daily refresh
+  push:
+    branches: [main]
+    paths:
+      - 'data/**'
+      - 'docs/**'
+      - 'scripts/build-dashboard.mjs'
+      - '.github/workflows/pages.yml'
+  issues:
+    types: [opened, edited, labeled, unlabeled, closed, reopened]
+
+permissions:
+  contents: read
+  issues: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Build dashboard.json
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/build-dashboard.mjs
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - name: Deploy to Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/docs/data/dashboard.json
+++ b/docs/data/dashboard.json
@@ -1,0 +1,44 @@
+{
+  "generated_at": "2026-06-04T00:32:20Z",
+  "repo": "agenticsorg/community-projects",
+  "note": "Scores are intentionally omitted pending the committee decision on the score-confidentiality model (issue #27).",
+  "committee": {
+    "name": "Open Source Committee",
+    "quorum_rule": "simple_majority",
+    "members": [
+      {
+        "login": "michaeloboyle",
+        "name": "Michael O'Boyle",
+        "role": "chair"
+      },
+      {
+        "login": "nicholas-ruest",
+        "name": "Nick Ruest",
+        "role": "member"
+      },
+      {
+        "login": "mrjcleaver",
+        "name": "Martin Cleaver",
+        "role": "member"
+      },
+      {
+        "login": "shaal",
+        "name": "Ofer Shaal",
+        "role": "member"
+      },
+      {
+        "login": "inde5media",
+        "name": "Mat Mathews",
+        "role": "member"
+      }
+    ]
+  },
+  "submissions": [],
+  "approved": [],
+  "stats": {
+    "committee_size": 5,
+    "submissions_total": 0,
+    "by_status": {},
+    "approved_total": 0
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Agentics Open Source Committee — Dashboard</title>
+<style>
+  :root {
+    --bg: #fbfbf9; --fg: #1c1c1a; --muted: #6b6b66; --line: #e4e4df;
+    --card: #ffffff; --accent: #2f6f4f;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 32px 20px 64px; }
+  header h1 { font-size: 22px; margin: 0 0 4px; }
+  header p { color: var(--muted); margin: 0; }
+  .stats { display: flex; flex-wrap: wrap; gap: 12px; margin: 24px 0 8px; }
+  .stat { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 12px 16px; min-width: 110px; }
+  .stat .n { font-size: 22px; font-weight: 600; }
+  .stat .l { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+  h2 { font-size: 15px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 40px 0 12px; border-bottom: 1px solid var(--line); padding-bottom: 6px; }
+  .members { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; }
+  .member { display: flex; align-items: center; gap: 12px; background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; }
+  .member img { width: 40px; height: 40px; border-radius: 50%; background: #eee; }
+  .member .name { font-weight: 600; }
+  .member a { color: var(--muted); text-decoration: none; font-size: 13px; }
+  .member .role { margin-left: auto; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--accent); }
+  table { width: 100%; border-collapse: collapse; background: var(--card); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+  th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+  tr:last-child td { border-bottom: none; }
+  td .desc { color: var(--muted); font-size: 13px; }
+  a.proj { color: var(--accent); text-decoration: none; font-weight: 600; }
+  .badge { display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--line); white-space: nowrap; }
+  .badge.status-pending-review { background: #fff7e6; border-color: #f0d9a8; }
+  .badge.status-approved { background: #e8f5ee; border-color: #b8dcc6; }
+  .badge.status-rejected { background: #fdecec; border-color: #f2c0c0; }
+  .badge.status-deferred { background: #eef0f5; }
+  .empty { color: var(--muted); background: var(--card); border: 1px dashed var(--line); border-radius: 8px; padding: 24px; text-align: center; }
+  .note { color: var(--muted); font-size: 13px; margin: 8px 0 0; }
+  footer { color: var(--muted); font-size: 12px; margin-top: 48px; border-top: 1px solid var(--line); padding-top: 12px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1 id="title">Open Source Committee</h1>
+    <p id="subtitle">Agentics Foundation — project intake dashboard</p>
+  </header>
+
+  <div class="stats" id="stats"></div>
+
+  <h2>Committee Members</h2>
+  <div class="members" id="members"></div>
+
+  <h2>Submissions</h2>
+  <div id="submissions"></div>
+  <p class="note" id="score-note"></p>
+
+  <h2>Approved Projects</h2>
+  <div id="approved"></div>
+
+  <footer id="footer"></footer>
+</div>
+
+<script>
+const esc = (s) => String(s ?? '').replace(/[&<>"']/g, (c) => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' }[c]));
+const fmtDate = (s) => s ? new Date(s).toISOString().slice(0, 10) : '';
+
+function renderStats(d) {
+  const s = d.stats || {};
+  const cells = [
+    ['Members', s.committee_size],
+    ['Submissions', s.submissions_total],
+    ['Approved', s.approved_total],
+  ];
+  document.getElementById('stats').innerHTML = cells.map(
+    ([l, n]) => `<div class="stat"><div class="n">${esc(n ?? 0)}</div><div class="l">${esc(l)}</div></div>`
+  ).join('');
+}
+
+function renderMembers(d) {
+  const m = (d.committee && d.committee.members) || [];
+  document.getElementById('members').innerHTML = m.map((p) => `
+    <div class="member">
+      <img src="https://github.com/${encodeURIComponent(p.login)}.png?size=80" alt="" loading="lazy" />
+      <div>
+        <div class="name">${esc(p.name || p.login)}</div>
+        <a href="https://github.com/${encodeURIComponent(p.login)}" target="_blank" rel="noopener">@${esc(p.login)}</a>
+      </div>
+      <div class="role">${esc(p.role || 'member')}</div>
+    </div>`).join('');
+}
+
+function renderSubmissions(d) {
+  const subs = d.submissions || [];
+  const el = document.getElementById('submissions');
+  if (!subs.length) {
+    el.innerHTML = '<div class="empty">No submissions yet. New project-submission issues will appear here automatically.</div>';
+  } else {
+    el.innerHTML = `<table><thead><tr>
+      <th>Project</th><th>Category</th><th>Status</th><th>Submitter</th><th>Submitted</th>
+    </tr></thead><tbody>${subs.map((s) => `
+      <tr>
+        <td><a class="proj" href="${esc(s.url)}" target="_blank" rel="noopener">${esc(s.name)}</a>
+            <div class="desc">${esc(s.description)}</div></td>
+        <td>${s.category ? `<span class="badge">${esc(s.category)}</span>` : '—'}</td>
+        <td><span class="badge status-${esc(s.status)}">${esc(s.status)}</span></td>
+        <td>${s.submitter ? `<a href="https://github.com/${encodeURIComponent(s.submitter)}" target="_blank" rel="noopener">@${esc(s.submitter)}</a>` : '—'}</td>
+        <td>${esc(fmtDate(s.created_at))}</td>
+      </tr>`).join('')}</tbody></table>`;
+  }
+  document.getElementById('score-note').textContent = d.note || '';
+}
+
+function renderApproved(d) {
+  const a = d.approved || [];
+  const el = document.getElementById('approved');
+  if (!a.length) {
+    el.innerHTML = '<div class="empty">No approved projects yet.</div>';
+    return;
+  }
+  el.innerHTML = `<table><thead><tr>
+    <th>Project</th><th>Category</th><th>Approved</th>
+  </tr></thead><tbody>${a.map((p) => `
+    <tr>
+      <td><a class="proj" href="${esc(p.repo_url || p.url || '#')}" target="_blank" rel="noopener">${esc(p.name || p.title || 'project')}</a></td>
+      <td>${p.category ? `<span class="badge">${esc(p.category)}</span>` : '—'}</td>
+      <td>${esc(fmtDate(p.approved_at || p.date))}</td>
+    </tr>`).join('')}</tbody></table>`;
+}
+
+fetch('./data/dashboard.json', { cache: 'no-store' })
+  .then((r) => { if (!r.ok) throw new Error('dashboard.json not found'); return r.json(); })
+  .then((d) => {
+    if (d.committee && d.committee.name) {
+      document.getElementById('title').textContent = d.committee.name;
+    }
+    renderStats(d);
+    renderMembers(d);
+    renderSubmissions(d);
+    renderApproved(d);
+    const when = d.generated_at ? new Date(d.generated_at).toISOString().replace('T', ' ').slice(0, 16) + ' UTC' : 'unknown';
+    document.getElementById('footer').innerHTML =
+      `Generated ${esc(when)} · source <a href="https://github.com/${esc(d.repo || '')}" target="_blank" rel="noopener">${esc(d.repo || '')}</a>`;
+  })
+  .catch((e) => {
+    document.getElementById('submissions').innerHTML =
+      `<div class="empty">Could not load dashboard data (${esc(e.message)}).</div>`;
+  });
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,45 +3,60 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="theme-color" content="#E25C3D" />
 <title>Agentics Open Source Committee — Dashboard</title>
 <style>
+  /* Brand tokens mirrored from production www.agentics.org:
+     IBM Plex Mono + Barlow Condensed, coral primary #E25C3D, warm cream bg,
+     rounded corners + pill badges. */
+  @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Barlow+Condensed:wght@600;700&display=swap');
   :root {
-    --bg: #fbfbf9; --fg: #1c1c1a; --muted: #6b6b66; --line: #e4e4df;
-    --card: #ffffff; --accent: #2f6f4f;
+    --bg: #fefbf6; --fg: #1f1f1f; --muted: #736e64; --line: #e3e1de;
+    --card: #ffffff; --brand: #e25c3d; --brand-dark: #c24a2f; --brand-tint: #ffe8e0;
+    --radius: 16px; --radius-sm: 10px;
+    --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+    --font-display: "Barlow Condensed", sans-serif;
   }
   * { box-sizing: border-box; }
   body {
     margin: 0; background: var(--bg); color: var(--fg);
-    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    font-family: var(--font-mono); font-size: 14px; line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
   }
   .wrap { max-width: 960px; margin: 0 auto; padding: 32px 20px 64px; }
-  header h1 { font-size: 22px; margin: 0 0 4px; }
-  header p { color: var(--muted); margin: 0; }
+  h1, h2 { font-family: var(--font-display); text-transform: uppercase; font-weight: 700; letter-spacing: 0.005em; }
+  header { border-bottom: 3px solid var(--brand); padding-bottom: 16px; }
+  header h1 { font-size: 36px; margin: 0 0 2px; line-height: 1; }
+  header p { color: var(--muted); margin: 0; font-size: 13px; }
   .stats { display: flex; flex-wrap: wrap; gap: 12px; margin: 24px 0 8px; }
-  .stat { background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 12px 16px; min-width: 110px; }
-  .stat .n { font-size: 22px; font-weight: 600; }
-  .stat .l { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
-  h2 { font-size: 15px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 40px 0 12px; border-bottom: 1px solid var(--line); padding-bottom: 6px; }
-  .members { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; }
-  .member { display: flex; align-items: center; gap: 12px; background: var(--card); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; }
-  .member img { width: 40px; height: 40px; border-radius: 50%; background: #eee; }
+  .stat { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 16px 20px; min-width: 120px; flex: 1; }
+  .stat .n { font-family: var(--font-display); font-size: 32px; font-weight: 700; line-height: 1; color: var(--brand); }
+  .stat .l { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; margin-top: 4px; }
+  h2 { font-size: 19px; color: var(--fg); margin: 44px 0 12px; padding-bottom: 6px; }
+  .members { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: 12px; }
+  .member { display: flex; align-items: center; gap: 12px; background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 12px 14px; }
+  .member img { width: 42px; height: 42px; border-radius: 50%; background: #eee; }
   .member .name { font-weight: 600; }
-  .member a { color: var(--muted); text-decoration: none; font-size: 13px; }
-  .member .role { margin-left: auto; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--accent); }
-  table { width: 100%; border-collapse: collapse; background: var(--card); border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
-  th, td { text-align: left; padding: 10px 12px; border-bottom: 1px solid var(--line); vertical-align: top; }
-  th { font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+  .member a { color: var(--muted); text-decoration: none; font-size: 12px; }
+  .member a:hover { color: var(--brand); }
+  .member .role { margin-left: auto; font-family: var(--font-display); font-size: 11px; text-transform: uppercase; letter-spacing: .06em; color: var(--brand); }
+  .panel { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); overflow: hidden; }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { text-align: left; padding: 12px 14px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { font-family: var(--font-display); font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); font-weight: 600; }
   tr:last-child td { border-bottom: none; }
-  td .desc { color: var(--muted); font-size: 13px; }
-  a.proj { color: var(--accent); text-decoration: none; font-weight: 600; }
-  .badge { display: inline-block; font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--line); white-space: nowrap; }
-  .badge.status-pending-review { background: #fff7e6; border-color: #f0d9a8; }
-  .badge.status-approved { background: #e8f5ee; border-color: #b8dcc6; }
-  .badge.status-rejected { background: #fdecec; border-color: #f2c0c0; }
-  .badge.status-deferred { background: #eef0f5; }
-  .empty { color: var(--muted); background: var(--card); border: 1px dashed var(--line); border-radius: 8px; padding: 24px; text-align: center; }
-  .note { color: var(--muted); font-size: 13px; margin: 8px 0 0; }
+  td .desc { color: var(--muted); font-size: 12.5px; margin-top: 3px; }
+  a.proj { color: var(--brand); text-decoration: none; font-weight: 600; }
+  a.proj:hover { color: var(--brand-dark); text-decoration: underline; }
+  .badge { display: inline-block; font-size: 11px; padding: 2px 10px; border-radius: 999px; border: 1px solid var(--line); white-space: nowrap; text-transform: uppercase; letter-spacing: .03em; }
+  .badge.status-pending-review { background: var(--brand-tint); border-color: var(--brand); color: var(--brand-dark); }
+  .badge.status-approved { background: #eef7f0; border-color: #b8dcc6; color: #2f6f4f; }
+  .badge.status-rejected { background: #fdecec; border-color: #f2c0c0; color: #b23b3b; }
+  .badge.status-deferred { background: #f3f1ee; color: var(--muted); }
+  .empty { color: var(--muted); background: var(--card); border: 1px dashed var(--line); border-radius: var(--radius); padding: 24px; text-align: center; }
+  .note { color: var(--muted); font-size: 12.5px; margin: 8px 0 0; }
   footer { color: var(--muted); font-size: 12px; margin-top: 48px; border-top: 1px solid var(--line); padding-top: 12px; }
+  footer a, .note a, td a { color: var(--brand); }
 </style>
 </head>
 <body>
@@ -101,7 +116,7 @@ function renderSubmissions(d) {
   if (!subs.length) {
     el.innerHTML = '<div class="empty">No submissions yet. New project-submission issues will appear here automatically.</div>';
   } else {
-    el.innerHTML = `<table><thead><tr>
+    el.innerHTML = `<div class="panel"><table><thead><tr>
       <th>Project</th><th>Category</th><th>Status</th><th>Submitter</th><th>Submitted</th>
     </tr></thead><tbody>${subs.map((s) => `
       <tr>
@@ -111,7 +126,7 @@ function renderSubmissions(d) {
         <td><span class="badge status-${esc(s.status)}">${esc(s.status)}</span></td>
         <td>${s.submitter ? `<a href="https://github.com/${encodeURIComponent(s.submitter)}" target="_blank" rel="noopener">@${esc(s.submitter)}</a>` : '—'}</td>
         <td>${esc(fmtDate(s.created_at))}</td>
-      </tr>`).join('')}</tbody></table>`;
+      </tr>`).join('')}</tbody></table></div>`;
   }
   document.getElementById('score-note').textContent = d.note || '';
 }
@@ -123,14 +138,14 @@ function renderApproved(d) {
     el.innerHTML = '<div class="empty">No approved projects yet.</div>';
     return;
   }
-  el.innerHTML = `<table><thead><tr>
+  el.innerHTML = `<div class="panel"><table><thead><tr>
     <th>Project</th><th>Category</th><th>Approved</th>
   </tr></thead><tbody>${a.map((p) => `
     <tr>
       <td><a class="proj" href="${esc(p.repo_url || p.url || '#')}" target="_blank" rel="noopener">${esc(p.name || p.title || 'project')}</a></td>
       <td>${p.category ? `<span class="badge">${esc(p.category)}</span>` : '—'}</td>
       <td>${esc(fmtDate(p.approved_at || p.date))}</td>
-    </tr>`).join('')}</tbody></table>`;
+    </tr>`).join('')}</tbody></table></div>`;
 }
 
 fetch('./data/dashboard.json', { cache: 'no-store' })

--- a/scripts/build-dashboard.mjs
+++ b/scripts/build-dashboard.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+// Builds docs/data/dashboard.json from the committee config, the approved-projects
+// registry, and the submission issues. Run by .github/workflows/pages.yml.
+//
+// Scores are intentionally NOT included: the score-confidentiality model is an open
+// committee decision (issue #27). Add scores here only once that decision lands.
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+
+const REPO = process.env.GITHUB_REPOSITORY || 'agenticsorg/community-projects';
+const TOKEN = process.env.GITHUB_TOKEN;
+const API = 'https://api.github.com';
+
+async function gh(path) {
+  const res = await fetch(`${API}${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(TOKEN ? { Authorization: `Bearer ${TOKEN}` } : {}),
+    },
+  });
+  if (!res.ok) throw new Error(`GitHub API ${path} -> ${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+const names = (labels) => labels.map((l) => (typeof l === 'string' ? l : l.name));
+const labelValue = (labels, prefix) => {
+  const hit = names(labels).find((n) => n.startsWith(prefix));
+  return hit ? hit.slice(prefix.length) : null;
+};
+
+function shortDescription(body, max = 220) {
+  if (!body) return '';
+  const text = body
+    .replace(/\r/g, '')
+    .replace(/^#+ .*$/gm, '')   // drop markdown headings / template section titles
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
+}
+
+async function allIssues() {
+  const out = [];
+  for (let page = 1; ; page += 1) {
+    const batch = await gh(`/repos/${REPO}/issues?state=all&per_page=100&page=${page}`);
+    out.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return out;
+}
+
+const config = JSON.parse(await readFile('data/committee-config.json', 'utf8'));
+const approved = JSON.parse(await readFile('data/approved-projects.json', 'utf8'));
+
+const issues = await allIssues();
+const submissions = issues
+  .filter((i) => !i.pull_request) // the issues endpoint also returns PRs
+  .filter((i) => names(i.labels).some((n) => n.startsWith('status:') || n.startsWith('category:')))
+  .map((i) => ({
+    number: i.number,
+    name: i.title.replace(/^\[Project Submission\]\s*/i, '').trim(),
+    description: shortDescription(i.body),
+    category: labelValue(i.labels, 'category:'),
+    status: labelValue(i.labels, 'status:') || (i.state === 'closed' ? 'closed' : 'open'),
+    submitter: i.user?.login ?? null,
+    created_at: i.created_at,
+    url: i.html_url,
+  }))
+  .sort((a, b) => b.created_at.localeCompare(a.created_at));
+
+const byStatus = {};
+for (const s of submissions) byStatus[s.status] = (byStatus[s.status] ?? 0) + 1;
+
+const dashboard = {
+  generated_at: new Date().toISOString(),
+  repo: REPO,
+  note: 'Scores are intentionally omitted pending the committee decision on the score-confidentiality model (issue #27).',
+  committee: {
+    name: config.committee_name,
+    quorum_rule: config.quorum_rule,
+    members: config.members,
+  },
+  submissions,
+  approved,
+  stats: {
+    committee_size: config.members.length,
+    submissions_total: submissions.length,
+    by_status: byStatus,
+    approved_total: approved.length,
+  },
+};
+
+await mkdir('docs/data', { recursive: true });
+await writeFile('docs/data/dashboard.json', `${JSON.stringify(dashboard, null, 2)}\n`);
+console.log(
+  `dashboard.json: ${config.members.length} members, ${submissions.length} submissions, ${approved.length} approved.`,
+);


### PR DESCRIPTION
A public, static dashboard for the Open Source Committee: **members**, **submissions** (name / description / category / status / submitter / date), and the **approved-projects registry**. Makes the intake process legible — directly serves the committee's governance-credibility / auditability mission.

## How it works (no new infra pattern)

Fits the existing Actions-first, file-based model:

- **`scripts/build-dashboard.mjs`** — reads `data/committee-config.json` + `data/approved-projects.json` and the submission issues (any issue labeled `status:*` / `category:*`), writes a single snapshot `docs/data/dashboard.json`. Node 20 built-ins only, no dependencies.
- **`.github/workflows/pages.yml`** — regenerates the snapshot and deploys `docs/` to Pages on: issue events, pushes to `data/**`, a daily cron, and manual dispatch.
- **`docs/index.html`** — static shell that loads the one local `dashboard.json`. No per-visitor GitHub API calls, so **no rate-limit exposure**; the snapshot is itself a versioned, auditable artifact.

Seeded `dashboard.json` is included so the page renders immediately (5 members today; updates to 6 once #19 merges and the workflow runs).

## Scores are deliberately omitted (issue #27)

The dashboard shows **status, not scores**. Displaying scores collides with the open score-confidentiality decision (#27). Wiring scores in is a one-spot follow-up in `build-dashboard.mjs` once #27 lands.

## Activation

The workflow's first run auto-enables Pages (`configure-pages` `enablement: true`), so **merging publishes the site**. To stage the code without going live, hold the merge or flip `enablement: false`. Nothing runs from a feature branch, so this PR changes nothing until merged.

## Not included (intentional, follow-ups)
- Scores / vote tallies — gated on #27
- Pagination beyond 100 issues per page (fine until volume grows)