### PR TITLE
Fix: notify committee members on submission (HITL handoff)

### DIFF
--- a/.github/workflows/governance-agent.yml
+++ b/.github/workflows/governance-agent.yml
@@ -64,6 +64,18 @@ jobs:
             const body = context.payload.issue.body || '';
             const submitter = context.payload.issue.user.login;
 
+            // HITL notification: build @mention list of eligible scorers (roster minus submitter)
+            let committeeMention = '';
+            try {
+              const cfg = JSON.parse(fs.readFileSync('data/committee-config.json', 'utf8'));
+              const eligible = cfg.members
+                .map(m => m.login)
+                .filter(login => login !== submitter);
+              if (eligible.length) {
+                committeeMention = eligible.map(l => '@' + l).join(' ');
+              }
+            } catch (e) { /* config missing: fall back to generic prompt */ }
+
             function extract(label) {
               const re = new RegExp(`### ${label}\\s*\\n\\s*(.+)`, 'i');
               const m = body.match(re);
@@ -332,7 +344,9 @@ jobs:
               '',
               '#### Next Steps',
               '',
-              'Committee members: please score this submission using:',
+              committeeMention
+                ? `${committeeMention}: please score this submission using:`
+                : 'Committee members: please score this submission using:',
               '```',
               '/score mission:N quality:N clarity:N impact:N risk:N',
               '```',


### PR DESCRIPTION
## Root cause

When a new project submission is filed, the Governance Agent's `case-brief` job posts a case brief whose Next Steps section reads "Committee members: please score this submission using:". That text @-mentions no one. GitHub only sends a notification when a specific user (or team) is @-mentioned, so no eligible scorer was ever pinged. The pipeline had no targeted notify step, so the human-in-the-loop handoff stalled silently: the brief was posted, but nobody was told it was their turn to act.

This is the failure observed on the SummaryBot submission (#33), which sat unscored after triage despite the case brief posting end to end.

## The fix

In the `case-brief` job's `github-script` step, after the submitter login is parsed, build an `@mention` list of eligible scorers from the existing `data/committee-config.json` (the full roster minus the submitter, since a submitter cannot score their own issue). The Next Steps prompt then @-mentions those members so GitHub fires a real notification.

- Reuses the existing `data/committee-config.json`, the same file the vote workflows already read via `fs.readFileSync`. No new file, no new config shape.
- Adds no new workflow permissions (the job already checks out the repo and uses `fs`).
- Degrades gracefully: if the config is missing or unreadable, it falls back to the original generic "Committee members:" text inside a try/catch.

Minimal change: two hunks, 15 insertions, 1 deletion, scoped entirely to the `case-brief` job. No other workflows or lines touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)